### PR TITLE
Allow script to run through all pages in sonar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ docker build -t export-sonarqube-metric:v0.1 .
 
 ```bash
 docker run -d --name export-sonarqube \
+-e SONAR_BASE_URL=http://sonar.yourGroup.com:9876 \
 -e SONAR_USER=admin \
 -e SONAR_PASSWORD=admin \
+-e INFLUX_URL=192.168.xx.xxx \
 -e INFLUX_USER=admin \
 -e INFLUX_PASSWORD=admin \
 -e INFLUX_DB=sonarqube_exporter \

--- a/sonar_collector_docker/sonar-client.py
+++ b/sonar_collector_docker/sonar-client.py
@@ -25,14 +25,22 @@ class SonarApiClient:
         return r.json()
     
     def get_all_ids(self, endpoint):
-        data = self._make_request(endpoint)
+        pageIndex = 1
+        totalCollectedIds = 0
+        totalIds = -1
         ids = []
-        for component in data['components']:
-            dict = {
-                'id': component['id'],
-                'key': component['key']
-            }
-            ids.append(dict)
+        while (totalIds != totalCollectedIds):
+            data = self._make_request(endpoint+'&p={}'.format(pageIndex))
+            totalIds = data['paging']['total']
+            totalCollectedIds += len(data['components'])
+
+            for component in data['components']:
+                dict = {
+                    'id': component['id'],
+                    'key': component['key']
+                }
+                ids.append(dict)
+            pageIndex = pageIndex +1
         return ids
     
     def get_all_available_metrics(self, endpoint):


### PR DESCRIPTION
This pull request will allow the script to run through all pages of SonarQube to get all project ids.